### PR TITLE
Make clientID unique

### DIFF
--- a/sonoffSocket.ino
+++ b/sonoffSocket.ino
@@ -163,10 +163,14 @@ void MqttCallback(char* topic, byte* payload, unsigned int length) {
 }
 
 void MqttReconnect() {
+  String clientID = "SonoffSocket_"; // 13 chars
+  clientID += WiFi.macAddress();//17 chars
+
   while (!client.connected()) {
     Serial.print("Connect to MQTT-Broker");
-    if (client.connect("SonoffSocket")) {
-      Serial.println("connected");
+    if (client.connect(clientID.c_str())) {
+      Serial.print("connected as clientID:");
+      Serial.println(clientID);
       //publish ready
       client.publish(mqtt_out_topic, "mqtt client ready");
       //subscribe in topic


### PR DESCRIPTION
My MQTT broker Mosquitto would close all "old" connections for the same clientID on connect.
Which resulted in 2 sockets continously connecting because they would be kicked by the other socket again.

In order to be able to identify them and in order to use the same image for all sockets, i used the MAC address to make the clientID unique.
Privacy should not be a concern, since my sockets don"t surf the WWW :) 